### PR TITLE
Enable setting chat on create meeting requests

### DIFF
--- a/lib/webex_api/meeting_request.rb
+++ b/lib/webex_api/meeting_request.rb
@@ -38,7 +38,7 @@ module WebexApi
 
     def get_meeting_body(xml, conf_name, meeting_key, options)
       xml.enableOptions{
-        xml.chat options[:chat]
+        xml.chat options[:chat] || true
         xml.audioVideo true
         xml.poll true
         xml.voip true

--- a/lib/webex_api/meeting_request.rb
+++ b/lib/webex_api/meeting_request.rb
@@ -4,7 +4,7 @@ module WebexApi
     def initialize(client)
       super(client)
     end
-  
+
     def create_meeting(conf_name,options={})
       body = get_createmeeting_body(conf_name, options)
       perform_request(body)
@@ -38,7 +38,7 @@ module WebexApi
 
     def get_meeting_body(xml, conf_name, meeting_key, options)
       xml.enableOptions{
-        xml.chat true
+        xml.chat options[:chat]
         xml.audioVideo true
         xml.poll true
         xml.voip true

--- a/lib/webex_api/version.rb
+++ b/lib/webex_api/version.rb
@@ -1,3 +1,3 @@
 module WebexApi
-  VERSION = "0.3.7"
+  VERSION = "0.3.8"
 end


### PR DESCRIPTION
Instead of setting chat to true by default, set it to the `:chat` value in the options hash passed in by the user, or true if nothing is passed in