### PR TITLE
Pass time zone in create meeting request

### DIFF
--- a/lib/webex_api/meeting_request.rb
+++ b/lib/webex_api/meeting_request.rb
@@ -98,6 +98,7 @@ module WebexApi
         if options[:scheduled_date]
           xml.startDate options[:scheduled_date].strftime("%m/%d/%Y %T") rescue nil
           xml.timeZoneID options[:time_zone_id].to_i unless options[:time_zone_id].nil?
+          xml.timeZone options[:time_zone] unless options[:time_zone].nil?
         else
           options[:scheduled_date].to_s + "1"
           xml.startDate

--- a/lib/webex_api/version.rb
+++ b/lib/webex_api/version.rb
@@ -1,3 +1,3 @@
 module WebexApi
-  VERSION = "0.4.7"
+  VERSION = "0.4.8"
 end


### PR DESCRIPTION
## Description of the change

+ In `lib/webex_api/meeting_request.rb` in `#get_meeting_body` pass in `timeZone` in the xml schedule options.

## Type of change
- [X] New feature (non-breaking change that adds functionality)

## Related issues

## Checklists

### Development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Changes have been reviewed by at least one other engineer
