### PR TITLE
add in support to automatically lock rooms

### DIFF
--- a/lib/webex_api/meeting_request.rb
+++ b/lib/webex_api/meeting_request.rb
@@ -86,6 +86,10 @@ module WebexApi
       xml.metaData{
         xml.confName conf_name
       }
+      xml.attendeeOptions{
+        xml.autoLock true if options[:auto_lock]
+        xml.autoLockWaitTime options[:auto_lock_wait_time]
+      }
       if options[:meeting_password] != nil && options[:meeting_password].strip != ''
         xml.accessControl{
           xml.meetingPassword options[:meeting_password]

--- a/lib/webex_api/version.rb
+++ b/lib/webex_api/version.rb
@@ -1,3 +1,3 @@
 module WebexApi
-  VERSION = "0.4.8"
+  VERSION = "0.4.9"
 end


### PR DESCRIPTION
## Description of the change

> Adds in support for locking of schedule meetings. If this flag is set to true, all participants will start in the webex waiting room instead of automatically being dragged into the meeting 


