### PR TITLE
Handle cases wherein there are no suberrors in the error response

### DIFF
--- a/lib/webex_api/request.rb
+++ b/lib/webex_api/request.rb
@@ -66,9 +66,9 @@ module WebexApi
         @error.gsbStatus = xml_data.at_xpath('/message/header/response/gsbStatus').text rescue nil
         @error.exceptionID = xml_data.at_xpath('/message/header/response/exceptionID').text rescue nil
 
-        sub_errors_in_response = xml_data.at_xpath('/message/header/response/subErrors').children
+        sub_errors_in_response = xml_data.at_xpath('/message/header/response/subErrors')&.children
 
-        if sub_errors_in_response.any? {|c| c.name == 'subError'}
+        if sub_errors_in_response&.any? {|c| c.name == 'subError'}
           @error.sub_errors = sub_errors_in_response.map do |sub_error|
             sub_error.children.map.with_object({}) do |sub_error_field, o|
               o[sub_error_field.name] = sub_error_field.text


### PR DESCRIPTION
## Description of the change

I there are no suberrors in the XML response, just skip over the suberror parsing code

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

#20 

## Checklists

### Development

### Code review 

- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment or otherwise notified
- [ ] Changes have been reviewed by at least one other engineer
