### PR TITLE
openTime implementation

### DIFF
--- a/lib/webex_api/meeting_request.rb
+++ b/lib/webex_api/meeting_request.rb
@@ -111,6 +111,9 @@ module WebexApi
           xml.startDate
         end
         xml.duration(options[:duration].to_i)
+        if options[:open_time]
+          xml.openTime options[:open_time].to_i
+        end
       }
       xml.telephony{
         xml.telephonySupport options[:telephony_mode] || 'CALLIN'

--- a/lib/webex_api/version.rb
+++ b/lib/webex_api/version.rb
@@ -1,3 +1,3 @@
 module WebexApi
-  VERSION = "0.4.15"
+  VERSION = "0.4.16"
 end


### PR DESCRIPTION
## Description of the change

Allows the openTime parameter to be set on meetings. This can be used to prevent users from entering the meeting without a host.

## Type of change
- [X] New feature (non-breaking change that adds functionality)

## Checklists

### Code review 

- [X]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [X] "Ready for review" label attached to the PR and reviewers mentioned in a comment or otherwise notified
- [ ] Changes have been reviewed by at least one other engineer
