### PR TITLE
CC-1886 - XML API Gem - Add Repeat Rule To Meeting Creation

### DIFF
--- a/lib/webex_api/meeting_request.rb
+++ b/lib/webex_api/meeting_request.rb
@@ -131,21 +131,21 @@ module WebexApi
         }
       end
 
-      xml.repeat{
+      xml.repeat {
         xml.repeatType options[:repeat_type] if options[:repeat_type].present?
         xml.interval options[:interval].to_i if options[:interval].present?
         xml.afterMeetingNumber options[:after_meeting_number] if options[:after_meeting_number].present?
         xml.dayInWeek {
-          options[:day_in_week].each{ |day| xml.day day } if options[:day_in_week].present?
-        }
+          options[:day_in_week].each{ |day| xml.day day }
+        } if options[:day_in_week].present?
         xml.expirationDate options[:expiration_date]&.strftime("%m/%d/%Y %T") if options[:expiration_date].present?
-        xml.dayInMonth = options[:day_in_month] if options[:day_in_month]
-        xml.weekInMonth = options[:week_in_month] if options[:week_in_month]
-        xml.monthInYear = options[:month_in_year] if options[:month_in_year]
-        xml.dayInYear = options[:day_in_year] if options[:day_in_year]
-        xml.isException = options[:is_exception] if options[:is_exception]
-        xml.seriesMeetingKey = options[:series_meeting_key] if options[:series_meeting_key]
-        xml.hasException = options[:has_exception] if options[:has_exception]
+        xml.dayInMonth options[:day_in_month] if options[:day_in_month].present?
+        xml.weekInMonth options[:week_in_month] if options[:week_in_month].present?
+        xml.monthInYear options[:month_in_year] if options[:month_in_year].present?
+        xml.dayInYear options[:day_in_year] if options[:day_in_year].present?
+        xml.isException options[:is_exception] if options[:is_exception].present?
+        xml.seriesMeetingKey options[:series_meeting_key] if options[:series_meeting_key].present?
+        xml.hasException options[:has_exception] if options[:has_exception].present?
       }
 
     end

--- a/lib/webex_api/meeting_request.rb
+++ b/lib/webex_api/meeting_request.rb
@@ -130,6 +130,24 @@ module WebexApi
           }
         }
       end
+
+      xml.repeat{
+        xml.repeatType options[:repeat_type] if options[:repeat_type].present?
+        xml.interval options[:interval].to_i if options[:interval].present?
+        xml.afterMeetingNumber options[:after_meeting_number] if options[:after_meeting_number].present?
+        xml.dayInWeek {
+          options[:day_in_week].each{ |day| xml.day day } if options[:day_in_week].present?
+        }
+        xml.expirationDate options[:expiration_date]&.strftime("%m/%d/%Y %T") if options[:expiration_date].present?
+        xml.dayInMonth = options[:day_in_month] if options[:day_in_month]
+        xml.weekInMonth = options[:week_in_month] if options[:week_in_month]
+        xml.monthInYear = options[:month_in_year] if options[:month_in_year]
+        xml.dayInYear = options[:day_in_year] if options[:day_in_year]
+        xml.isException = options[:is_exception] if options[:is_exception]
+        xml.seriesMeetingKey = options[:series_meeting_key] if options[:series_meeting_key]
+        xml.hasException = options[:has_exception] if options[:has_exception]
+      }
+
     end
 
     def get_meeting(meeting_key)

--- a/lib/webex_api/version.rb
+++ b/lib/webex_api/version.rb
@@ -1,3 +1,3 @@
 module WebexApi
-  VERSION = "0.4.15"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
## Description of the change

> Implement the XML API's recurring meeting scheduling functionality by adding all repeat attributes into the options that get passed into a meeting request.

## Type of change
- [x] New feature (non-breaking change that adds functionality)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment or otherwise notified
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 