### PR TITLE
CC-1866 - Bug Fix - Conditionally Add Repeat XML element based on presence of repeatType attribute

### DIFF
--- a/lib/webex_api/meeting_request.rb
+++ b/lib/webex_api/meeting_request.rb
@@ -134,23 +134,24 @@ module WebexApi
         }
       end
 
-      xml.repeat {
-        xml.repeatType options[:repeat_type] if options[:repeat_type].present?
-        xml.interval options[:interval].to_i if options[:interval].present?
-        xml.afterMeetingNumber options[:after_meeting_number] if options[:after_meeting_number].present?
-        xml.dayInWeek {
-          options[:day_in_week].each{ |day| xml.day day }
-        } if options[:day_in_week].present?
-        xml.expirationDate options[:expiration_date]&.strftime("%m/%d/%Y %T") if options[:expiration_date].present?
-        xml.dayInMonth options[:day_in_month] if options[:day_in_month].present?
-        xml.weekInMonth options[:week_in_month] if options[:week_in_month].present?
-        xml.monthInYear options[:month_in_year] if options[:month_in_year].present?
-        xml.dayInYear options[:day_in_year] if options[:day_in_year].present?
-        xml.isException options[:is_exception] if options[:is_exception].present?
-        xml.seriesMeetingKey options[:series_meeting_key] if options[:series_meeting_key].present?
-        xml.hasException options[:has_exception] if options[:has_exception].present?
-      }
-
+      if options[:repeat_type]
+        xml.repeat {
+          xml.repeatType options[:repeat_type] if options[:repeat_type].present?
+          xml.interval options[:interval].to_i if options[:interval].present?
+          xml.afterMeetingNumber options[:after_meeting_number] if options[:after_meeting_number].present?
+          xml.dayInWeek {
+            options[:day_in_week].each{ |day| xml.day day }
+          } if options[:day_in_week].present?
+          xml.expirationDate options[:expiration_date]&.strftime("%m/%d/%Y %T") if options[:expiration_date].present?
+          xml.dayInMonth options[:day_in_month] if options[:day_in_month].present?
+          xml.weekInMonth options[:week_in_month] if options[:week_in_month].present?
+          xml.monthInYear options[:month_in_year] if options[:month_in_year].present?
+          xml.dayInYear options[:day_in_year] if options[:day_in_year].present?
+          xml.isException options[:is_exception] if options[:is_exception].present?
+          xml.seriesMeetingKey options[:series_meeting_key] if options[:series_meeting_key].present?
+          xml.hasException options[:has_exception] if options[:has_exception].present?
+        }
+      end
     end
 
     def get_meeting(meeting_key)


### PR DESCRIPTION
## Description of the change

If `repeatType` is not included in the options hash, then do not create the self-closing <repeat/> tag, because the API will complain that `repeatType` is a required field. If the meeting does not repeat, then this element should be excluded. This preserves backwards compatibility.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

[CC-1866](https://cloverhound.atlassian.net/browse/CC-1886)

## Checklists

### Development

- [x] Lint rules pass locally

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment or otherwise notified
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 


[CC-1866]: https://cloverhound.atlassian.net/browse/CC-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ